### PR TITLE
Add .cherrystudio persistence

### DIFF
--- a/com.cherry_ai.CherryStudio.yml
+++ b/com.cherry_ai.CherryStudio.yml
@@ -14,6 +14,7 @@ finish-args:
   - --share=network
   - --device=dri
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --persist=.cherrystudio
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 modules:
   - name: cherrystudio


### PR DESCRIPTION
Ref: https://docs.cherry-ai.com/advanced-basic/mcp/install

Currently, cherrystudio places the programs uv and bun required for MCP in hard coded form.