### PR TITLE
fix(run.sh): Add '--wayland-text-input-version=3' to default electron…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ FLAGS+=(
     '--ozone-platform-hint=auto'
     '--enable-features=WaylandWindowDecorations'
     '--enable-wayland-ime'
+    '--wayland-text-input-version=3'
 )
 
 env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/cherrystudio/cherrystudio "${FLAGS[@]}" "$@"


### PR DESCRIPTION
This change adds the `--wayland-text-input-version=3` flag to the application's startup script (`run.sh`).

This flag is necessary to enable support for the latest Wayland text input protocol (version 3), which improves IME (Input Method Editor) support, particularly for CJK (Chinese, Japanese, Korean) users. This resolves issues with input methods not functioning correctly under Wayland sessions.