### PR TITLE
fix(metainfo): Update project license to AGPL-3.0-only and correct donation URL path

### DIFF
--- a/com.cherry_ai.CherryStudio.metainfo.xml
+++ b/com.cherry_ai.CherryStudio.metainfo.xml
@@ -8,7 +8,7 @@
     <name>CherryHQ</name>
   </developer>
   <metadata_license>MIT</metadata_license>
-  <project_license>Apache-2.0</project_license>
+  <project_license>AGPL-3.0-only</project_license>
   <update_contact>kangfenmao@gmail.com</update_contact>
   <project_group>CherryHQ</project_group>
   <description>
@@ -311,7 +311,7 @@
   </releases>
   <url type="homepage">https://cherry-ai.com/</url>
   <url type="bugtracker">https://github.com/CherryHQ/cherry-studio/issues</url>
-  <url type="donation">https://github.com/CherryHQ/cherry-studio/blob/main/docs/sponsor.md</url>
+  <url type="donation">https://github.com/CherryHQ/cherry-studio/blob/main/docs/zh/guides/sponsor.md</url>
   <url type="contribute">https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md</url>
   <categories>
     <category>Utility</category>


### PR DESCRIPTION
This PR updates the project metadata in `com.cherry_ai.CherryStudio.metainfo.xml` with two key changes:

- **License Update**: Changed the project license from `Apache-2.0` to `AGPL-3.0-only` to reflect the current licensing terms
- **URL Correction**: Updated the donation URL from `/docs/sponsor.md` to `/docs/zh/guides/sponsor.md` to point to the correct localized sponsor documentation

These changes ensure the Flatpak metadata accurately represents the project's current licensing and provides users with the correct donation information.

Closes #80 